### PR TITLE
Add example to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # DS18B20
 Driver for the DS18B20 temperature sensor.
+
+## Example
+
+```toit
+import ds18b20 show Ds18b20
+import gpio
+
+GPIO_PIN_NUM ::= 32
+
+main:
+  pin := gpio.Pin GPIO_PIN_NUM
+  ds18b20 := Ds18b20 pin
+  print "Temperature: $(%.2f ds18b20.read_temperature) C"
+  ds18b20.close
+  pin.close
+```

--- a/examples/read_temp.toit
+++ b/examples/read_temp.toit
@@ -23,6 +23,6 @@ main:
     print "Temperature: $(%.2f ds18b20.read_temperature) C"
 
   // The following close isn't necessary, as the periodic timer above will
-  // never stop. In other cases, it is important to close the ds18b20.
+  // never stop. In other cases, it is important to close the DS18B20.
   ds18b20.close
   pin.close

--- a/tests/esp32/scratchpad.toit
+++ b/tests/esp32/scratchpad.toit
@@ -70,7 +70,7 @@ run_test device/ds18b20.Ds18b20 --parasitic/bool:
   expect_equals 9 scratchpad.size
   expect_equals 0x12 scratchpad[2]
   expect_equals 0x34 scratchpad[3]
-  // As before: the ds18b20 forces the configuration bit 8 to 0, and bits 0-4 to 1.
+  // As before: the DS18B20 forces the configuration bit 8 to 0, and bits 0-4 to 1.
   expect_equals 0x1F scratchpad[4]
 
   // Recall the values from the EEPROM.


### PR DESCRIPTION
Also use "DS18B20" (capitalized) whenever we refer to the sensor.