### PR TITLE
Update GPIO usage for SDK 2.0 alpha 196

### DIFF
--- a/examples/multi_bus.toit
+++ b/examples/multi_bus.toit
@@ -5,7 +5,6 @@
 import ds18b20 show Ds18b20
 import one-wire
 import one-wire.family show FAMILY-DS18B20 family-id family-to-string
-import gpio
 
 /**
 Demonstrates how to use multiple DS18B20 sensors on the same bus.
@@ -14,8 +13,7 @@ Demonstrates how to use multiple DS18B20 sensors on the same bus.
 GPIO-PIN-NUM ::= 18
 
 main:
-  pin := gpio.Pin GPIO-PIN-NUM
-  bus := one-wire.Bus pin
+  bus := one-wire.Bus GPIO-PIN-NUM
 
   // A broadcast device to address all devices on the bus.
   broadcast := Ds18b20.broadcast --bus=bus
@@ -82,4 +80,3 @@ main:
   devices.do: it.close
   broadcast.close
   bus.close
-  pin.close

--- a/examples/read_temp.toit
+++ b/examples/read_temp.toit
@@ -3,18 +3,16 @@
 // be found in the EXAMPLES_LICENSE file.
 
 import ds18b20 show Ds18b20
-import gpio
 
 GPIO-PIN-NUM ::= 32
 
 main:
-  pin := gpio.Pin GPIO-PIN-NUM
 
   // For parasitic devices, the data-pin is frequently not yet pulled up
   // by a resistor. In this case, use the '--pull_up' flag to use the pin's
   // internal pull-up resistor. The internal pull-up is, in theory, too
   // strong for the 1-wire bus, but it works in practice.
-  ds18b20 := Ds18b20 pin
+  ds18b20 := Ds18b20 GPIO-PIN-NUM
 
   is-parasitic := ds18b20.is-parasitic
   print "is parasitic: $is-parasitic"
@@ -25,4 +23,3 @@ main:
   // The following close isn't necessary, as the periodic timer above will
   // never stop. In other cases, it is important to close the DS18B20.
   ds18b20.close
-  pin.close

--- a/examples/scratchpad.toit
+++ b/examples/scratchpad.toit
@@ -4,13 +4,11 @@
 
 import ds18b20 show Ds18b20
 import expect show *
-import gpio
 
 GPIO-PIN-NUM ::= 18
 
 main:
-  pin := gpio.Pin GPIO-PIN-NUM
-  ds18b20 := Ds18b20 pin
+  ds18b20 := Ds18b20 GPIO-PIN-NUM
 
   // Use the low and high temperature registers as external memory.
   scratchpad := ds18b20.read-scratchpad
@@ -54,4 +52,3 @@ main:
   expect-equals 0x34 scratchpad[3]
 
   ds18b20.close
-  pin.close

--- a/examples/shared_bus.toit
+++ b/examples/shared_bus.toit
@@ -3,14 +3,12 @@
 // be found in the EXAMPLES_LICENSE file.
 
 import ds18b20 show Ds18b20
-import gpio
 import one-wire
 
 GPIO-PIN-NUM ::= 32
 
 main:
-  pin := gpio.Pin GPIO-PIN-NUM
-  bus := one-wire.Bus pin
+  bus := one-wire.Bus GPIO-PIN-NUM
 
   id := 0x753c01f095df0228
   driver := Ds18b20 --id=id --bus=bus
@@ -26,4 +24,3 @@ main:
   // never stop. In other cases, it is important to close the driver.
   driver.close
   bus.close
-  pin.close

--- a/package.yaml
+++ b/package.yaml
@@ -1,7 +1,7 @@
 name: ds18b20
 description: Driver for the DS18B20 temperature sensor.
 environment:
-  sdk: ^2.0.0-alpha.194.1
+  sdk: ^2.0.0-alpha.196
 dependencies:
   one_wire:
     url: github.com/toitware/toit-1-wire

--- a/package.yaml
+++ b/package.yaml
@@ -1,11 +1,11 @@
 name: ds18b20
 description: Driver for the DS18B20 temperature sensor.
 environment:
-  sdk: ^2.0.0-alpha.144
+  sdk: ^2.0.0-alpha.194.1
 dependencies:
   one_wire:
     url: github.com/toitware/toit-1-wire
-    version: ^2.1.0
+    version: ^2.6.0
   sensors:
     url: github.com/toitware/toit-sensors
     version: ^1.0.0

--- a/src/ds18b20.toit
+++ b/src/ds18b20.toit
@@ -58,6 +58,9 @@ class Ds18b20:
   If there are multiple sensors, then the driver misbehaves. In that
     case use $(Ds18b20.constructor --id --bus) instead.
 
+  The $pin is a GPIO number. Passing a $gpio.Pin is deprecated; provide the integer
+    GPIO number instead.
+
   If $pull-up is true, then uses the pin's pullup resistor to power the
     1-wire bus. Many modules that take 3 inputs (VCC, GND, DATA) already
     connect the DATA pin to the VCC using a 4.7k resistor. In that case,
@@ -66,7 +69,9 @@ class Ds18b20:
 
   If $skip-id-read is true, then the driver does not read the device id.
   */
-  constructor pin/gpio.Pin --skip-id-read/bool=false --pull-up/bool=false:
+  // __TYPE-MIGRATION__ pin: gpio.Pin. Deprecated. Provide an integer instead.
+  // __TYPE-MIGRATION__ pin: int
+  constructor pin/any --skip-id-read/bool=false --pull-up/bool=false:
     bus_ = one-wire.Bus pin --pull-up=pull-up
     owns-bus_ = true
     is-single_ = true

--- a/src/provider.toit
+++ b/src/provider.toit
@@ -2,7 +2,6 @@
 // Use of this source code is governed by an MIT-style license that can be found
 // in the LICENSE file.
 
-import gpio
 import one-wire
 import sensors.providers
 
@@ -14,16 +13,14 @@ MINOR ::= 0
 
 class TemperatureSensor implements providers.TemperatureSensor-v1:
   bus_/one-wire.Bus? := null
-  pin_/gpio.Pin? := ?
   sensor_/Ds18b20? := ?
 
   constructor pin/int --id/int? --pull-up/bool=false:
-    pin_ = gpio.Pin pin
     if id:
-      bus_ = one-wire.Bus pin_ --pull-up=pull-up
+      bus_ = one-wire.Bus pin --pull-up=pull-up
       sensor_ = Ds18b20 --id=id --bus=bus_
     else:
-      sensor_ = Ds18b20 pin_
+      sensor_ = Ds18b20 pin
           --skip-id-read  // There is no way to read the ID through the service.
           --pull-up=pull-up
 
@@ -37,9 +34,6 @@ class TemperatureSensor implements providers.TemperatureSensor-v1:
     if sensor_:
       sensor_.close
       sensor_ = null
-    if pin_:
-      pin_.close
-      pin_ = null
 
 install pin/int --id/int?=null --pull-up/bool=false -> providers.Provider:
   provider := providers.Provider NAME

--- a/tests/esp32/multi_bus.toit
+++ b/tests/esp32/multi_bus.toit
@@ -3,7 +3,6 @@
 // be found in the EXAMPLES_LICENSE file.
 
 import expect show *
-import gpio
 
 import ds18b20 show Ds18b20
 import one-wire
@@ -23,8 +22,7 @@ If all sensors are parasitic without any pull-up resistor, then
 GPIO-PIN-NUM ::= 18
 
 main:
-  pin := gpio.Pin GPIO-PIN-NUM
-  bus := one-wire.Bus pin
+  bus := one-wire.Bus GPIO-PIN-NUM
 
   // A broadcast device to address all devices on the bus.
   broadcast := Ds18b20.broadcast --bus=bus
@@ -98,6 +96,5 @@ main:
   devices.do: it.close
   broadcast.close
   bus.close
-  pin.close
 
   print "All tests passed."

--- a/tests/esp32/scratchpad.toit
+++ b/tests/esp32/scratchpad.toit
@@ -11,7 +11,6 @@ Connect a single parasitic DS18B20 to GPIO pin 19.
 */
 
 import expect show *
-import gpio
 
 import ds18b20
 
@@ -19,10 +18,10 @@ POWERED-PIN := 18
 PARASITIC-PIN := 19
 
 main:
-  powered := ds18b20.Ds18b20 (gpio.Pin POWERED-PIN)
+  powered := ds18b20.Ds18b20 POWERED-PIN
   run-test powered --parasitic=false
 
-  parasitic := ds18b20.Ds18b20 (gpio.Pin PARASITIC-PIN) --pull-up
+  parasitic := ds18b20.Ds18b20 PARASITIC-PIN --pull-up
   run-test parasitic --parasitic
 
   print "All tests passed."


### PR DESCRIPTION
Updates the package for the SDK 2.0.0-alpha.196 peripheral API by passing integer GPIO numbers to peripheral constructors and raising the SDK constraint. It also brings the package publishing workflow up to date where needed.